### PR TITLE
fix/#115 : 내 글 관리 - 데이터 없음 스크린 추가

### DIFF
--- a/feature/lectureevaluation/my/src/main/java/com/suwiki/feature/lectureevaluation/my/MyEvaluationContract.kt
+++ b/feature/lectureevaluation/my/src/main/java/com/suwiki/feature/lectureevaluation/my/MyEvaluationContract.kt
@@ -14,7 +14,10 @@ data class MyEvaluationState(
   val showDeleteLectureEvaluationDialog: Boolean = false,
   val showDeleteExamEvaluationDialog: Boolean = false,
   val showLackPointDialog: Boolean = false,
-)
+) {
+  val showLectureEmptyScreen: Boolean = myLectureEvaluationList.isEmpty()
+  val showExamEmptyScreen: Boolean = myExamEvaluationList.isEmpty()
+}
 
 sealed interface MyEvaluationSideEffect {
   data object PopBackStack : MyEvaluationSideEffect

--- a/feature/lectureevaluation/my/src/main/java/com/suwiki/feature/lectureevaluation/my/MyEvaluationScreen.kt
+++ b/feature/lectureevaluation/my/src/main/java/com/suwiki/feature/lectureevaluation/my/MyEvaluationScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
@@ -11,6 +12,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -20,7 +22,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.suwiki.core.designsystem.component.appbar.SuwikiAppBarWithTitle
 import com.suwiki.core.designsystem.component.container.SuwikiEditContainer
@@ -28,6 +32,7 @@ import com.suwiki.core.designsystem.component.dialog.SuwikiDialog
 import com.suwiki.core.designsystem.component.loading.LoadingScreen
 import com.suwiki.core.designsystem.component.tabbar.SuwikiTabBar
 import com.suwiki.core.designsystem.component.tabbar.TabTitle
+import com.suwiki.core.designsystem.theme.Gray95
 import com.suwiki.core.designsystem.theme.SuwikiTheme
 import com.suwiki.core.designsystem.theme.White
 import com.suwiki.core.model.enums.LectureEvaluationTab
@@ -160,21 +165,29 @@ fun MyEvaluationScreen(
     ) { page ->
       when (LectureEvaluationTab.entries[page]) {
         LectureEvaluationTab.LECTURE_EVALUATION -> {
-          MyLectureEvaluationLazyColumn(
-            itemList = uiState.myLectureEvaluationList,
-            listState = lectureEvaluationListState,
-            onClickLectureEditButton = onClickLectureEvaluationEditButton,
-            onClickDeleteButton = onClickLectureEvaluationDeleteButton,
-          )
+          if (uiState.showLectureEmptyScreen) {
+            EmptyScreen()
+          } else {
+            MyLectureEvaluationLazyColumn(
+              itemList = uiState.myLectureEvaluationList,
+              listState = lectureEvaluationListState,
+              onClickLectureEditButton = onClickLectureEvaluationEditButton,
+              onClickDeleteButton = onClickLectureEvaluationDeleteButton,
+            )
+          }
         }
 
         LectureEvaluationTab.EXAM_INFO -> {
-          MyExamEvaluationLazyColumn(
-            itemList = uiState.myExamEvaluationList,
-            listState = examEvaluationListState,
-            onClickExamEditButton = onClickExamEvaluationEditButton,
-            onClickDeleteButton = onClickExamEvaluationDeleteButton,
-          )
+          if (uiState.showExamEmptyScreen) {
+            EmptyScreen()
+          } else {
+            MyExamEvaluationLazyColumn(
+              itemList = uiState.myExamEvaluationList,
+              listState = examEvaluationListState,
+              onClickExamEditButton = onClickExamEvaluationEditButton,
+              onClickDeleteButton = onClickExamEvaluationDeleteButton,
+            )
+          }
         }
       }
     }
@@ -245,6 +258,19 @@ fun MyLectureEvaluationLazyColumn(
       )
     }
   }
+}
+
+@Composable
+fun EmptyScreen() {
+  Text(
+    modifier = Modifier
+      .padding(top = 150.dp)
+      .fillMaxSize(),
+    text = stringResource(R.string.empty_screen_text),
+    textAlign = TextAlign.Center,
+    style = SuwikiTheme.typography.header4,
+    color = Gray95,
+  )
 }
 
 @Composable

--- a/feature/lectureevaluation/my/src/main/res/values/strings.xml
+++ b/feature/lectureevaluation/my/src/main/res/values/strings.xml
@@ -9,4 +9,5 @@
   <string name="delete_dialog_body">강의평가를 정말로 삭제하시겠습니까?\n현재 보유 포인트 : %dp</string>
   <string name="lack_point_dialog_header">포인트가 부족합니다.</string>
   <string name="lack_point_dialog_body">현재 보유 포인트 : %dp</string>
+  <string name="empty_screen_text">등록된 평가가 없어요</string>
 </resources>


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 내 글 관리 - 데이터 없음 스크린 추가

🌱 PR 포인트
- 텍스트의 padding 값은 이용제한 내역 데이터 없음 스크린 참고했습니다.

## 📸 스크린샷
|스크린샷|
|:--:|
|![Screenshot_20240124-180146_SUWIKI](https://github.com/uswLectureEvaluation/Android/assets/107917980/c09a6311-c0cc-46a9-9bf0-1e457d5d8ccc)|

## 📮 관련 이슈
- Resolved: #115 
