### PR TITLE
Fix/#127 개설학과 필터링 버그 해결

### DIFF
--- a/feature/lectureevaluation/viewerreporter/src/main/java/com/suwiki/feature/lectureevaluation/viewerreporter/LectureEvaluationViewModel.kt
+++ b/feature/lectureevaluation/viewerreporter/src/main/java/com/suwiki/feature/lectureevaluation/viewerreporter/LectureEvaluationViewModel.kt
@@ -9,6 +9,8 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.lastOrNull
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import org.orbitmvi.orbit.Container
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.annotation.OrbitExperimental
@@ -17,6 +19,7 @@ import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.postSideEffect
 import org.orbitmvi.orbit.syntax.simple.reduce
 import org.orbitmvi.orbit.viewmodel.container
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -26,6 +29,8 @@ class LectureEvaluationViewModel @Inject constructor(
 ) : ContainerHost<LectureEvaluationState, LectureEvaluationSideEffect>, ViewModel() {
   override val container: Container<LectureEvaluationState, LectureEvaluationSideEffect> =
     container(LectureEvaluationState())
+
+  private val mutex: Mutex = Mutex()
 
   private val currentState
     get() = container.stateFlow.value
@@ -81,35 +86,37 @@ class LectureEvaluationViewModel @Inject constructor(
     majorType: String = currentState.selectedOpenMajor,
     needClear: Boolean,
   ) = intent {
-    val currentList = if (needClear) {
-      page = 1
-      reduce { state.copy(isLoading = true) }
-      emptyList()
-    } else {
-      state.lectureEvaluationList
-    }
+    mutex.withLock {
+      val currentList = if (needClear) {
+        page = 1
+        reduce { state.copy(isLoading = true) }
+        emptyList()
+      } else {
+        state.lectureEvaluationList
+      }
 
-    getLectureEvaluationListUseCase(
-      RetrieveLectureEvaluationAverageListUseCase.Param(
-        search = search,
-        option = LectureAlign.entries[alignPosition].query,
-        page = page,
-        majorType = majorType,
-      ),
-    ).onSuccess { newList ->
-      handleGetLectureEvaluationListSuccess(
-        alignPosition = alignPosition,
-        majorType = majorType,
-        currentList = currentList,
-        newList = newList,
-      )
-    }.onFailure {
-      postSideEffect(LectureEvaluationSideEffect.HandleException(it))
-    }
+      getLectureEvaluationListUseCase(
+        RetrieveLectureEvaluationAverageListUseCase.Param(
+          search = search,
+          option = LectureAlign.entries[alignPosition].query,
+          page = page,
+          majorType = majorType,
+        ),
+      ).onSuccess { newList ->
+        handleGetLectureEvaluationListSuccess(
+          alignPosition = alignPosition,
+          majorType = majorType,
+          currentList = currentList,
+          newList = newList,
+        )
+      }.onFailure {
+        postSideEffect(LectureEvaluationSideEffect.HandleException(it))
+      }
 
-    if (needClear) {
-      postSideEffect(LectureEvaluationSideEffect.ScrollToTop)
-      reduce { state.copy(isLoading = false) }
+      if (needClear) {
+        postSideEffect(LectureEvaluationSideEffect.ScrollToTop)
+        reduce { state.copy(isLoading = false) }
+      }
     }
   }
 
@@ -146,6 +153,7 @@ class LectureEvaluationViewModel @Inject constructor(
       postSideEffect(LectureEvaluationSideEffect.NavigateLectureEvaluationDetail(id))
     }
   }
+
   private fun showOnboardingBottomSheet() = intent { reduce { state.copy(showOnboardingBottomSheet = true) } }
   fun hideOnboardingBottomSheet() = intent { reduce { state.copy(showOnboardingBottomSheet = false) } }
 

--- a/feature/lectureevaluation/viewerreporter/src/main/java/com/suwiki/feature/lectureevaluation/viewerreporter/LectureEvaluationViewModel.kt
+++ b/feature/lectureevaluation/viewerreporter/src/main/java/com/suwiki/feature/lectureevaluation/viewerreporter/LectureEvaluationViewModel.kt
@@ -19,7 +19,6 @@ import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.postSideEffect
 import org.orbitmvi.orbit.syntax.simple.reduce
 import org.orbitmvi.orbit.viewmodel.container
-import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 강의평가, 개설강좌 조회 시 특정 조건에서 개설학과 필터링이 되지 않는 현상 해결했습니다. 
- 특정 조건 : #127 

🌱 PR 포인트
- 새로운 강의평가 리스트를 불러오는 조건은 다음과 같습니다.
1. 리스트의 마지막 아이템이 보일 때
2. 개설 학과가 변경되었을 때

2가지 조건이 모두 충족된 경우 강의평가 리스트를 거의 동시에 2번 불러오게 되고 이때 Race Condition이 발생하게 됩니다.
리스트를 불러오는 함수를 임계 영역으로 설정해 문제를 해결했습니다.

## 📸 스크린샷
|스크린샷|
|:--:|
|파일첨부바람|

## 📮 관련 이슈
- Resolved: #127 
