### PR TITLE
chore: agp 8.5.0, hilt 2.50

### DIFF
--- a/build-logic/convention/src/main/java/com/kunize/convention/AndroidCompose.kt
+++ b/build-logic/convention/src/main/java/com/kunize/convention/AndroidCompose.kt
@@ -5,7 +5,7 @@ import org.gradle.api.Project
 import org.gradle.kotlin.dsl.dependencies
 
 internal fun Project.configureAndroidCompose(
-  commonExtension: CommonExtension<*, *, *, *, *>,
+  commonExtension: CommonExtension<*, *, *, *, *, *>,
 ) {
   commonExtension.apply {
     buildFeatures {

--- a/build-logic/convention/src/main/java/com/kunize/convention/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/java/com/kunize/convention/KotlinAndroid.kt
@@ -6,7 +6,7 @@ import org.gradle.api.plugins.ExtensionAware
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions
 
 internal fun Project.configureKotlinAndroid(
-  commonExtension: CommonExtension<*, *, *, *, *>,
+  commonExtension: CommonExtension<*, *, *, *, *, *>,
 ) {
   commonExtension.apply {
     compileSdk = Const.compileSdk
@@ -48,7 +48,7 @@ internal fun Project.configureKotlinAndroid(
   }
 }
 
-internal fun CommonExtension<*, *, *, *, *>.kotlinOptions(
+internal fun CommonExtension<*, *, *, *, *, *>.kotlinOptions(
   block: KotlinJvmOptions.() -> Unit,
 ) {
   (this as ExtensionAware).extensions.configure("kotlinOptions", block)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-android-gradle-plugin = "8.1.2"
+android-gradle-plugin = "8.5.0"
 material = "1.10.0"
 espresso = "3.4.0"
 ksp = "1.9.10-1.0.13"
@@ -44,7 +44,7 @@ retrofit = "2.9.0"
 retrofit-kotlinx-serialization-json = "1.0.0"
 okhttp = "4.11.0"
 
-hilt = "2.48"
+hilt = "2.50"
 room = "2.5.2"
 
 timber = "5.0.1"


### PR DESCRIPTION
## 📮 관련 이슈
- Resolved: #143


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - `android-gradle-plugin` 버전이 "8.1.2"에서 "8.5.0"으로 업데이트되었습니다.
  - `hilt` 버전이 "2.48"에서 "2.50"으로 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->